### PR TITLE
CMake polishing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,14 @@ cmake_minimum_required (VERSION 2.8 FATAL_ERROR)
 project ("Quick-DER" C)
 
 set (CMAKE_MACOSX_RPATH 0)  # Don't use rpaths (but we don't build executables anyway)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
+set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
-include(MacroEnsureOutOfSourceBuild)
+include (MacroEnsureOutOfSourceBuild)
+include (MacroAddUninstallTarget)
+include (MacroGitVersionInfo)
+include (MacroCreateConfigFiles)
+
 macro_ensure_out_of_source_build("Do not build Quick-DER in the source directory.")
-include(MacroAddUninstallTarget)
-add_uninstall_target()
-include(MacroGitVersionInfo)
 
 #
 # OPTIONS / BUILD SETTINGS
@@ -29,7 +30,7 @@ option (SPEC_ARPA2
 	"Build include files from ASN.1 specs for ARPA2 projects"
 	ON)
 
-get_version_from_git(Quick-DER 0.1.5)
+get_version_from_git (Quick-DER 0.1.5)
 
 enable_testing ()
 
@@ -39,24 +40,26 @@ enable_testing ()
 
 if (SPEC_RFC OR SPEC_ITU OR SPEC_ARPA2)
 	#TODO# depend on asn2quickder's "asn1ate" python package
-endif()
+endif ()
 
 
 #
 # BUILDING
 #
-add_subdirectory(lib)
+add_subdirectory (lib)
 if (SPEC_RFC)
-	add_subdirectory(rfc)
-endif()
+	add_subdirectory (rfc)
+endif ()
 if (SPEC_ITU)
-	add_subdirectory(itu)
-endif()
+	add_subdirectory (itu)
+endif ()
 if (SPEC_ARPA2)
-	add_subdirectory(arpa2)
-endif()
-add_subdirectory(tool)
-add_subdirectory(test)
+	add_subdirectory (arpa2)
+endif ()
+add_subdirectory (tool)
+add_subdirectory (test)
+
+add_uninstall_target ()
 
 #
 # PACKAGING
@@ -74,35 +77,4 @@ include (CPack)
 # projects, because Quick-DER can be found (and version information
 # obtained) automatically.
 #
-export(PACKAGE Quick-DER)
-# The CMake configuration files are written to different locations
-# depending on the host platform, since different conventions apply.
-if(WIN32 AND NOT CYGWIN)
-	set(DEF_INSTALL_CMAKE_DIR CMake)
-else()
-	set(DEF_INSTALL_CMAKE_DIR lib/cmake/Quick-DER)
-endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
-	"Installation directory for CMake files")
-
-# Calculate include/ relative to the installed place of the config file.
-file(RELATIVE_PATH REL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}"
-	"${CMAKE_INSTALL_PREFIX}/include")
-set(CONF_INCLUDE_DIRS "\${Quick-DER_CMAKE_DIR}/${REL_INCLUDE_DIR}")
-# Substitute in real values for the placeholders in the .in files,
-# create the files in the build tree, and install them.
-configure_file(Quick-DERConfig.cmake.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Quick-DERConfig.cmake" @ONLY)
-configure_file(Quick-DERConfigVersion.cmake.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Quick-DERConfigVersion.cmake" @ONLY)
-configure_file(Quick-DER.pc.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Quick-DER.pc" @ONLY)
-
-install(FILES
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Quick-DERConfig.cmake"
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Quick-DERConfigVersion.cmake"
-  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
-install(FILES 
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Quick-DER.pc"
-  DESTINATION "lib/pkgconfig/")
-
+create_config_files (Quick-DER)

--- a/cmake/ConfigVersion.cmake.in
+++ b/cmake/ConfigVersion.cmake.in
@@ -1,3 +1,7 @@
+# Template ConfigVersion file used by MacroCreateConfigFiles if
+# there is no package-specific file to use. File copied from
+# the CMake wiki.
+
 set(PACKAGE_VERSION "@_conf_version@")
  
 # Check whether the requested PACKAGE_FIND_VERSION is compatible

--- a/cmake/ConfigVersion.cmake.in
+++ b/cmake/ConfigVersion.cmake.in
@@ -1,4 +1,4 @@
-set(PACKAGE_VERSION "@Quick-DER_VERSION@")
+set(PACKAGE_VERSION "@_conf_version@")
  
 # Check whether the requested PACKAGE_FIND_VERSION is compatible
 if("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")

--- a/cmake/MacroASN1Header.cmake
+++ b/cmake/MacroASN1Header.cmake
@@ -1,3 +1,8 @@
+# ADD_ASN1_HEADER(<headername> <groupname>)
+#    Add a target to generate <headername>.h from the corresponding
+#    ASN.1 file <headername>.asn1. The target is added as a dependency
+#	 to <groupname>, which may be an empty target.
+#
 # Generation of C header files from ASN.1 sources
 # via the asn2quickder tool. The macro add_asn1_headers()
 # is the main API entry: give it a target name (e.g.
@@ -6,11 +11,16 @@
 # and a list of names. Each name must name a .asn1 file
 # (without the extension).
 #
-#
 #    add_custom_target(my-headers ALL)
 #    add_asn1_headers(my-headers rfc1 rfc2)
 #
 # This snippet requires files rfc1.asn1 and rfc2.asn1 to exist.
+
+# Copyright 2017, Adriaan de Groot <groot@kde.org>
+#
+# Redistribution and use is allowed according to the terms of the two-clause BSD license.
+#    https://opensource.org/licenses/BSD-2-Clause
+#    SPDX short identifier: BSD-2-Clause
 
 macro(add_asn1_header _headername _groupname)
 # Generate the header file in <quick-der/headername.h>

--- a/cmake/MacroAddUninstallTarget.cmake
+++ b/cmake/MacroAddUninstallTarget.cmake
@@ -1,3 +1,7 @@
+# ADD_UNINSTALL_TARGET()
+#    Add custom target 'uninstall' that removes all the files
+#    installed by this build (not recommended by CMake devs though).
+#
 # Add an uninstall target, as described on the CMake wiki.
 # Include this file, then call add_uninstall_target().
 # Requires a top-level cmake/ directory containing this

--- a/cmake/MacroCreateConfigFiles.cmake
+++ b/cmake/MacroCreateConfigFiles.cmake
@@ -1,4 +1,6 @@
-# Configuration-files writing
+# CREATE_CONFIG_FILES(<packagename>)
+#    Call this macro to generate CMake and pkg-config configuration
+#    files from templates found in the top-level source directory.
 #
 # Most ARPA2-related components write configuration-information
 # files and install them. There are two flavors:
@@ -16,6 +18,12 @@
 # the cmake/ directory, since there is nothing particularly special
 # for that file (as opposed to the other files, which need to 
 # specify paths, dependencies, and other things).
+
+# Copyright 2017, Adriaan de Groot <groot@kde.org>
+#
+# Redistribution and use is allowed according to the terms of the two-clause BSD license.
+#    https://opensource.org/licenses/BSD-2-Clause
+#    SPDX short identifier: BSD-2-Clause
 
 macro (create_config_files _packagename)
 	export (PACKAGE ${_packagename})

--- a/cmake/MacroCreateConfigFiles.cmake
+++ b/cmake/MacroCreateConfigFiles.cmake
@@ -1,0 +1,60 @@
+# Configuration-files writing
+#
+# Most ARPA2-related components write configuration-information
+# files and install them. There are two flavors:
+#
+#   - CMake config-info files (<foo>Config.cmake and <foo>ConfigVersion.cmake)
+#   - pkg-config files (<foo>.pc)
+#
+# The macro create_config_files() simplifies this process
+# by using named template files for all three output files.
+# Pass a package name (e.g. "Quick-DER") to the macro, and
+# the source files (e.g. <file>.in for the files named above
+# will be taken from the top-level source directory.
+#
+# As an (un)special case, the ConfigVersion file may be taken from
+# the cmake/ directory, since there is nothing particularly special
+# for that file (as opposed to the other files, which need to 
+# specify paths, dependencies, and other things).
+
+macro (create_config_files _packagename)
+	export (PACKAGE ${_packagename})
+	# The CMake configuration files are written to different locations
+	# depending on the host platform, since different conventions apply.
+	if (WIN32 AND NOT CYGWIN)
+		set (DEF_INSTALL_CMAKE_DIR CMake)
+	else ()
+		set (DEF_INSTALL_CMAKE_DIR lib/cmake/${_packagename})
+	endif ()
+	set (INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
+		"Installation directory for CMake files")
+
+	# Calculate include/ relative to the installed place of the config file.
+	file (RELATIVE_PATH REL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}"
+		"${CMAKE_INSTALL_PREFIX}/include")
+	set (CONF_INCLUDE_DIRS "\${${_packagename}_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+	# Substitute in real values for the placeholders in the .in files,
+	# create the files in the build tree, and install them.
+	configure_file (${PROJECT_SOURCE_DIR}/${_packagename}Config.cmake.in
+		"${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_packagename}Config.cmake" @ONLY)
+	set (_conf_version_filename ${PROJECT_SOURCE_DIR}/${_packagename}ConfigVersion.cmake.in)
+	if (NOT EXISTS ${_conf_version_filename})
+		# (un)special-case: use the generic version-checking file,
+		# assume ${_packagename}_VERSION exists and copy that to
+		# the generic version-variable for this file.
+		set (_conf_version_filename ${PROJECT_SOURCE_DIR}/cmake/ConfigVersion.cmake.in)
+		set (_conf_version ${${_packagename}_VERSION})
+	endif ()
+	configure_file (${_conf_version_filename}
+		"${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_packagename}ConfigVersion.cmake" @ONLY)
+	configure_file (${PROJECT_SOURCE_DIR}/${_packagename}.pc.in
+		"${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_packagename}.pc" @ONLY)
+
+	install (FILES
+		"${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_packagename}Config.cmake"
+		"${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_packagename}ConfigVersion.cmake"
+		DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+	install (FILES 
+	"${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_packagename}.pc"
+		DESTINATION "lib/pkgconfig/")
+endmacro ()

--- a/cmake/MacroEnsureOutOfSourceBuild.cmake
+++ b/cmake/MacroEnsureOutOfSourceBuild.cmake
@@ -1,4 +1,3 @@
-# - MACRO_ENSURE_OUT_OF_SOURCE_BUILD(<errorMessage>)
 # MACRO_ENSURE_OUT_OF_SOURCE_BUILD(<errorMessage>)
 #    Call this macro in your project if you want to enforce out-of-source builds.
 #    If an in-source build is detected, it will abort with the given error message.

--- a/cmake/MacroGitVersionInfo.cmake
+++ b/cmake/MacroGitVersionInfo.cmake
@@ -1,3 +1,8 @@
+# GET_VERSION_FROM_GIT(<appname> <default>)
+#    Uses git tags to determine a version name and sets <appname>_VERSION 
+#    (along with split-out _MAJOR, _MINOR and _PATCHLEVEL variables). If
+#    git isn't available, use <default> for version information (which should
+#    be a string in the format M.m.p).
 #
 # Version Information
 #
@@ -19,6 +24,12 @@
 # After the macro invocation, Quick-DER_VERSION is set according
 # to the git tag or 0.1.5.
 #
+
+# Copyright 2017, Adriaan de Groot <groot@kde.org>
+#
+# Redistribution and use is allowed according to the terms of the two-clause BSD license.
+#    https://opensource.org/licenses/BSD-2-Clause
+#    SPDX short identifier: BSD-2-Clause
 
 macro(get_version_from_git _appname _default)
 	find_package (Git QUIET)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,4 +1,4 @@
-# From the CMake wiki
+# From the CMake wiki; see MacroAddUninstallTarget.cmake
 
 if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
   message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")


### PR DESCRIPTION
This is polishing of the CMake stuff in Quick-DER, splitting the config-version stuff into its own macro, so that we can re-use it in LillyDAP and the ARPA2-howto.